### PR TITLE
Update wrapper.py

### DIFF
--- a/bio/samtools/stats/wrapper.py
+++ b/bio/samtools/stats/wrapper.py
@@ -17,4 +17,6 @@ region = snakemake.params.get("region", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 
-shell("samtools stats {extra} {snakemake.input} {bed} {region} > {snakemake.output} {log}")
+shell(
+    "samtools stats {extra} {snakemake.input} {bed} {region} > {snakemake.output} {log}"
+)

--- a/bio/samtools/stats/wrapper.py
+++ b/bio/samtools/stats/wrapper.py
@@ -8,10 +8,13 @@ __license__ = "MIT"
 
 from snakemake.shell import shell
 
+bed = snakemake.params.get("bed", None)
+if bed is not None:
+  bed = " -t " + bed
 
 extra = snakemake.params.get("extra", "")
 region = snakemake.params.get("region", "")
 log = snakemake.log_fmt_shell(stdout=False, stderr=True)
 
 
-shell("samtools stats {extra} {snakemake.input} {region} > {snakemake.output} {log}")
+shell("samtools stats {extra} {snakemake.input} {bed} {region} > {snakemake.output} {log}")

--- a/bio/samtools/stats/wrapper.py
+++ b/bio/samtools/stats/wrapper.py
@@ -10,7 +10,7 @@ from snakemake.shell import shell
 
 bed = snakemake.params.get("bed", None)
 if bed is not None:
-  bed = " -t " + bed
+    bed = " -t " + bed
 
 extra = snakemake.params.get("extra", "")
 region = snakemake.params.get("region", "")


### PR DESCRIPTION

### Description

make it possible to input a bed file as a separate params value.

### QC

For all wrappers added by this PR, I made sure that

* [ ] there is a test case which covers any introduced changes,
* [ ] `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* [ ] either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* [ ] rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* [ ] all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* [ ] wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* [ ] all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* [ ] `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* [ ] temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* [ ] the `meta.yaml` contains a link to the documentation of the respective tool or command,
* [ ] `Snakefile`s pass the linting (`snakemake --lint`),
* [ ] `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* [ ] Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
