### PR TITLE
feat: Cnvkit scatter

### DIFF
--- a/bio/cnvkit/diagram/environment.yaml
+++ b/bio/cnvkit/diagram/environment.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - cnvkit =0.9.10

--- a/bio/cnvkit/diagram/meta.yaml
+++ b/bio/cnvkit/diagram/meta.yaml
@@ -1,0 +1,13 @@
+name: "cnvkit diagram"
+description: >
+ Draw copy number (either individual bins (.cnn, .cnr) or segments (.cns)) on chromosomes as an ideogram. If both the bin-level log2 ratios and segmentation calls are given, show them side-by-side on each chromosome (segments on the left side, bins on the right side).
+url: https://cnvkit.readthedocs.io/en/stable/pipeline.html
+input:
+  - cns file (optional, if cnr is provided)
+  - cnr/cnn file (optional, if cns is provided)
+output:
+  - pdf report
+params:
+  - extra: additional parameters that will be forwarded to cnvkit diagram
+authors:
+  - Patrik Smeds

--- a/bio/cnvkit/diagram/test/Snakefile
+++ b/bio/cnvkit/diagram/test/Snakefile
@@ -1,0 +1,47 @@
+rule cnvkit_diagram_cns:
+    input:
+        "test.cns",
+    output:
+        "test.cns.pdf",
+    log:
+        "logs/test.cns.log",
+    params:
+        extra = "" # optional
+    wrapper:
+        "master/bio/cnvkit/diagram"
+
+rule cnvkit_diagram_cnr:
+    input:
+        "test.cnr",
+    output:
+        "test.cnr.pdf",
+    log:
+        "logs/test.cnr.log",
+    params:
+        extra = "" # optional
+    wrapper:
+        "master/bio/cnvkit/diagram"
+
+rule cnvkit_diagram_cnn:
+    input:
+        "test.cnn",
+    output:
+        "test.cnn.pdf",
+    log:
+        "logs/test.cnn.log",
+    params:
+        extra = "" # optional
+    wrapper:
+        "master/bio/cnvkit/diagram"
+
+rule cnvkit_diagram_cnscnr:
+    input:
+        ["test.cns", "test.cnr"]
+    output:
+        "test.cnscnr.pdf",
+    log:
+        "logs/test.cnscnr.log",
+    params:
+        extra = "" # optional
+    wrapper:
+        "master/bio/cnvkit/diagram"

--- a/bio/cnvkit/diagram/test/test.cnn
+++ b/bio/cnvkit/diagram/test/test.cnn
@@ -1,0 +1,2 @@
+chromosome	start	end	gene	depth	log2
+chr1	160786623	160786747	LY9	0.27178	-1.87949

--- a/bio/cnvkit/diagram/test/test.cnr
+++ b/bio/cnvkit/diagram/test/test.cnr
@@ -1,0 +1,2 @@
+chromosome	start	end	gene	log2	depth	weight
+chr1	160786623	160786747	LY9	-1.87949	0.27178	0.310777

--- a/bio/cnvkit/diagram/test/test.cns
+++ b/bio/cnvkit/diagram/test/test.cns
@@ -1,0 +1,2 @@
+chromosome	start	end	gene	log2	probes
+chr1	160786623	160786747	LY9	-1.87949	1

--- a/bio/cnvkit/diagram/wrapper.py
+++ b/bio/cnvkit/diagram/wrapper.py
@@ -1,0 +1,32 @@
+__author__ = "Patrik Smeds"
+__copyright__ = "Copyright 2023, Patrik Smeds"
+__email__ = "patrik.smeds@gmail.com"
+__license__ = "MIT"
+
+from snakemake.shell import shell
+
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+cns_file = [f for f in snakemake.input if f.endswith(".cns")]
+cnr_file = [f for f in snakemake.input if f.endswith(".cnr") or f.endswith(".cnn")]
+
+if cns_file:
+    if len(cns_file) > 1:
+        raise Exception(f"Expecting only one input cns file {cns_file}")
+    cns_file = f"-s {cns_file[0]}"
+
+if cnr_file:
+    if len(cnr_file) > 1:
+        raise Exception(f"Expecting only one input cnr file {cns_file}")
+    cnr_file = f"{cnr_file[0]}"
+
+extra = snakemake.params.get("extra", "")
+
+shell(
+    "(cnvkit.py diagram "
+    "{cns_file} "
+    "{cnr_file} "
+    "-o {snakemake.output} "
+    "{extra}) "
+    "{log}"
+)

--- a/bio/cnvkit/scatter/environment.yaml
+++ b/bio/cnvkit/scatter/environment.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - cnvkit =0.9.10

--- a/bio/cnvkit/scatter/meta.yaml
+++ b/bio/cnvkit/scatter/meta.yaml
@@ -1,0 +1,13 @@
+name: "cnvkit scatter"
+description: >
+ Plot bin-level log2 coverages and segmentation calls together. Without any further arguments, this plots the genome-wide copy number in a form familiar to those who have used array CGH.
+url: https://cnvkit.readthedocs.io/en/stable/plots.html?highlight=diagram#scatter
+input:
+  - cnr file
+  - cns file
+output:
+  - plot
+params:
+  - extra: additional parameters that will be forwarded to cnvkit scatter
+authors:
+  - Patrik Smeds

--- a/bio/cnvkit/scatter/test/Snakefile
+++ b/bio/cnvkit/scatter/test/Snakefile
@@ -1,0 +1,25 @@
+rule cnvkit_scatter_pdf:
+    input:
+        cnr="test.cnr",
+        cns="test.cns",
+    output:
+        "test.pdf",
+    log:
+        "logs/test.pdf.log",
+    params:
+        extra = "" # optional
+    wrapper:
+        "master/bio/cnvkit/scatter"
+
+rule cnvkit_scatter_png:
+    input:
+        cnr="test.cnr",
+        cns="test.cns",
+    output:
+        "test.png",
+    log:
+        "logs/test.png.log",
+    params:
+        extra = "" # optional
+    wrapper:
+        "master/bio/cnvkit/scatter"

--- a/bio/cnvkit/scatter/test/test.cnr
+++ b/bio/cnvkit/scatter/test/test.cnr
@@ -1,0 +1,2 @@
+chromosome	start	end	gene	log2	depth	weight
+chr1	160786623	160786747	LY9	-1.87949	0.27178	0.310777

--- a/bio/cnvkit/scatter/test/test.cns
+++ b/bio/cnvkit/scatter/test/test.cns
@@ -1,0 +1,2 @@
+chromosome	start	end	gene	log2	probes
+chr1	160786623	160786747	LY9	-1.87949	1

--- a/bio/cnvkit/scatter/wrapper.py
+++ b/bio/cnvkit/scatter/wrapper.py
@@ -1,0 +1,19 @@
+__author__ = "Patrik Smeds"
+__copyright__ = "Copyright 2023, Patrik Smeds"
+__email__ = "patrik.smeds@gmail.com"
+__license__ = "MIT"
+
+from snakemake.shell import shell
+
+log = snakemake.log_fmt_shell(stdout=False, stderr=True)
+
+extra = snakemake.params.get("extra", "")
+
+shell(
+    "(cnvkit.py scatter "
+    "-s {snakemake.input.cns} "
+    "{snakemake.input.cnr} "
+    "-o {snakemake.output} "
+    "{extra}) "
+    "{log}"
+)

--- a/test.py
+++ b/test.py
@@ -1181,45 +1181,25 @@ def test_bwa_mapping_meta():
     )
 
 @skip_if_not_modified
-def test_bwa_mapping_meta():
+def test_cnvkit_scatter():
     run(
-        "bio/cnvkit/diagram",
+        "bio/cnvkit/scatter",
         [
             "snakemake",
             "--cores",
             "1",
             "--use-conda",
-            "test.cns.pdf",
+            "test.png",
         ],
     )
     run(
-        "bio/cnvkit/diagram",
+        "bio/cnvkit/scatter",
         [
             "snakemake",
             "--cores",
             "1",
             "--use-conda",
-            "test.cnr.pdf",
-        ],
-    )
-    run(
-        "bio/cnvkit/diagram",
-        [
-            "snakemake",
-            "--cores",
-            "1",
-            "--use-conda",
-            "test.cnn.pdf",
-        ],
-    )
-    run(
-        "bio/cnvkit/diagram",
-        [
-            "snakemake",
-            "--cores",
-            "1",
-            "--use-conda",
-            "test.cnscnr.pdf",
+            "test.pdf",
         ],
     )
 

--- a/test.py
+++ b/test.py
@@ -1180,6 +1180,48 @@ def test_bwa_mapping_meta():
         ],
     )
 
+@skip_if_not_modified
+def test_bwa_mapping_meta():
+    run(
+        "bio/cnvkit/diagram",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "test.cns.pdf",
+        ],
+    )
+    run(
+        "bio/cnvkit/diagram",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "test.cnr.pdf",
+        ],
+    )
+    run(
+        "bio/cnvkit/diagram",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "test.cnn.pdf",
+        ],
+    )
+    run(
+        "bio/cnvkit/diagram",
+        [
+            "snakemake",
+            "--cores",
+            "1",
+            "--use-conda",
+            "test.cnscnr.pdf",
+        ],
+    )
 
 @skip_if_not_modified
 def test_enhanced_volcano():


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

### Description

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
